### PR TITLE
Allow MDNS to be used for name resolution

### DIFF
--- a/etc/nsswitch.conf
+++ b/etc/nsswitch.conf
@@ -4,7 +4,7 @@
 #
 group: compat
 group_compat: nis
-hosts: files dns
+hosts: files dns mdns
 networks: files
 passwd: compat
 passwd_compat: nis


### PR DESCRIPTION
This fixes things such as accessing freenas.local, Apple Devices, and other bonjour devices by name.